### PR TITLE
corrected copyright start year

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 app-autoscaler-release
 
-Copyright (c) 2013-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+Copyright (c) 2016-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
There was no CloudFoundry.org Foundation in 2013. All contributions to this repo by CFF members seem to have started in 2016.