### PR TITLE
move generated deployment manifest to project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ config/private.yml
 releases/*.tgz
 releases/**/*.tgz
 dev_releases
+deployments
 .blobs
 blobs
 .dev_builds

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ config/private.yml
 releases/*.tgz
 releases/**/*.tgz
 dev_releases
-deployments
+manifests
 .blobs
 blobs
 .dev_builds

--- a/jobs/apiserver/templates/pre-start.erb
+++ b/jobs/apiserver/templates/pre-start.erb
@@ -1,4 +1,6 @@
 #!/bin/bash 
+
+set -x
 <%
   # returns an empty array of the value is null
   def p_arr(property)

--- a/scripts/generate-bosh-lite-manifest
+++ b/scripts/generate-bosh-lite-manifest
@@ -83,7 +83,12 @@ if [[ "$(echo "$BOSH_STATUS" | grep Name)" != *"$EXPECTED_DIRECTOR_NAME"* ]]; th
   exit 1
 fi
 
-tmpdir=$(mktemp -d /tmp/autoscaler-bosh-lite-manifest.XXXXX)
+deployments_dir=$(cd $(dirname $(dirname $0)) && pwd)/deployments
+if [ ! -d ${deployments_dir} ]; then
+  mkdir ${deployments_dir}
+fi
+tmpdir=$(mktemp -d ${deployments_dir}/autoscaler-bosh-lite-manifest.XXXXX)
+
 director_uuid=${tmpdir}/director.yml
 printf "director_uuid: %s" $(bosh status --uuid) > ${director_uuid}
 

--- a/scripts/generate-bosh-lite-manifest
+++ b/scripts/generate-bosh-lite-manifest
@@ -83,11 +83,11 @@ if [[ "$(echo "$BOSH_STATUS" | grep Name)" != *"$EXPECTED_DIRECTOR_NAME"* ]]; th
   exit 1
 fi
 
-deployments_dir=$(cd $(dirname $(dirname $0)) && pwd)/deployments
-if [ ! -d ${deployments_dir} ]; then
-  mkdir ${deployments_dir}
+manifests_dir=$(cd $(dirname $(dirname $0)) && pwd)/manifests
+if [ ! -d ${manifests_dir} ]; then
+  mkdir ${manifests_dir}
 fi
-tmpdir=$(mktemp -d ${deployments_dir}/autoscaler-bosh-lite-manifest.XXXXX)
+tmpdir=$(mktemp -d ${manifests_dir}/autoscaler-bosh-lite-manifest.XXXXX)
 
 director_uuid=${tmpdir}/director.yml
 printf "director_uuid: %s" $(bosh status --uuid) > ${director_uuid}


### PR DESCRIPTION
[#143825851]

note: the change on apisever pre-start script is used to debug API severs deployment failures described in story https://www.pivotaltracker.com/n/projects/1566795/stories/143471329