### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bosh update cloud-config ./example/cloud-config.yml
 ./scripts/generate-bosh-lite-manifest \
 	-c <path to cf-release deployment manifest> \
 	-p ./example/property-overrides.yml \
-	-v v1
+	--v1
 ./scripts/deploy
 ```
 


### PR DESCRIPTION
According to the script file, it should be ```--v1``` not ```-v v1```.

[scripts/generate-bosh-lite-manifest]

```
OPTIONAL ARGUMENTS:
    -d <db-stub-path>           Path to database stub file.
    --v1                        Flag to use BOSH V1 manifest template
```