### PR TITLE
Update bosh-lite-manifest-template-v1.yml

### DIFF
--- a/templates/bosh-lite-manifest-template-v1.yml
+++ b/templates/bosh-lite-manifest-template-v1.yml
@@ -150,9 +150,9 @@ jobs:
       - name: servicebroker
         release: app-autoscaler
       - name: route_registrar
-      release: routing
-      consumes:
-        nats: {from: nats, deployment: cf}
+        release: routing
+        consumes:
+          nats: {from: nats, deployment: cf}
     properties:
       service_broker: (( service_broker_properties ))
       binding_db: (( bindingdb ))


### PR DESCRIPTION
#### [Issue]
When I tried to create a new yml file, this syntax error occured.
```
Generating BOSH V1 manifest using  bosh-lite-manifest-template-v1.yml as manifest template
2017/10/13 13:34:45 error parsing template [/home/minjeong/workspace/GitHub/PaaSXpert-AutoScaler/app-autoscaler-release/templates/bosh-lite-manifest-template-v1.yml]: yaml: [while parsing a block collection] did not find expected '-' indicator at line 153, column 7
```

#### [Related commit] 
https://github.com/cloudfoundry-incubator/app-autoscaler-release/commit/b85d5747f0b847b056fd6bdce31f63c9c0367cde#diff-b2d77745783e5b29a01b765fb1669bb7

#### [Solution]
I fixed the improper spacing.