### PR TITLE
Bump-up app-autoscaler

### DIFF
--- a/example/property-overrides.yml
+++ b/example/property-overrides.yml
@@ -92,7 +92,9 @@ metricscollector_properties:
   server:
     port: 6103
   collector:
-    refresh_interval: 30s
+    refresh_interval: 60s
+    collect_interval: 30s
+    save_interval: 5s
   ca_cert: (( app_autoscaler_ca_cert ))
   server_cert: (( metricscollector_server_cert ))
   server_key: (( metricscollector_server_key ))

--- a/jobs/metricscollector/spec
+++ b/jobs/metricscollector/spec
@@ -82,6 +82,9 @@ properties:
   metricscollector.collector.collect_interval:
     description: "the time interval to collect container metrics from loggregator"
     default: 30s
+  metricscollector.collector.save_interval:
+    description: "the time interval to save metrics in database"
+    default: 5s
   metricscollector.collector.collect_method:
     description: "the method to collect metrics from loggregator"
     default: "streaming"

--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -293,6 +293,10 @@ instance_groups:
           level: debug
         server:
           port: 6103
+        collector:
+          refresh_interval: 60s
+          collect_interval: 30s
+          save_interval: 5s
         enable_db_lock: false
         ca_cert: ((metricscollector_ca.ca))
         server_cert: ((metricscollector_server.certificate))


### PR DESCRIPTION
-  Delegate DB calls to separate goroutine in the metrics collector