### PR TITLE
Fix broker acceptance test for newer cf-cli versions

### DIFF
--- a/src/acceptance/broker/broker_test.go
+++ b/src/acceptance/broker/broker_test.go
@@ -35,7 +35,8 @@ var _ = Describe("AutoScaler Service Broker", func() {
 
 		bindService := cf.Cf("bind-service", appName, instanceName, "-c", "../assets/file/policy/invalid.json").Wait(cfg.DefaultTimeoutDuration())
 		Expect(bindService).To(Exit(1))
-		Eventually(bindService.Out).Should(gbytes.Say("instance.scaling_rules\\[1\\]\\.adjustment does not match pattern"))
+		combinedBuffer := gbytes.BufferWithBytes(append(bindService.Out.Contents(), bindService.Err.Contents()...))
+		Eventually(combinedBuffer).Should(gbytes.Say("instance.scaling_rules\\[1\\]\\.adjustment does not match pattern"))
 
 		By("Test bind&unbind with policy")
 		bindService = cf.Cf("bind-service", appName, instanceName, "-c", "../assets/file/policy/all.json").Wait(cfg.DefaultTimeoutDuration())


### PR DESCRIPTION
- Broker Acceptance test break for cf-cli version greater than 6.32