### PR TITLE
Add acceptance tests as a bosh task

### DIFF
--- a/jobs/acceptance/spec
+++ b/jobs/acceptance/spec
@@ -1,0 +1,118 @@
+---
+name: acceptance
+
+description: >
+  This job runs the AutoScaler user acceptance tests
+
+packages:
+- golang1.7
+- acceptance
+# cli
+
+templates:
+  run.erb: bin/run
+  config.json.erb: bin/config.json
+
+properties:
+  autoscaler.acceptance.service_name:
+    description: >
+      The name of the registered auto-scaler service, use cf marketplace to
+      determine the name.
+    default: autoscaler
+  autoscaler.acceptance.service_plan:
+    description: >
+      The plan name of the registered auto-scaler service, use cf marketplace
+      to determine the plan.
+    default: autoscaler-free-plan
+  autoscaler.eventgenerator.aggregator.aggregator_execute_interval:
+    description: >
+      How frequently metrics are aggregated. This value must match the value
+      configured in your deployment.
+    default: 120
+  autoscaler.acceptance.autoscaler_api:
+    description: AutoScaler API endpoint
+    example: autoscaler.bosh-lite.com
+  autoscaler.acceptance.api:
+    description: Cloud Controller API endpoint
+    example: api.bosh-lite.com
+  autoscaler.cf.username:
+    description: >
+      Name of a user in your CF instance with admin credentials. This admin user
+      must have the doppler.firehose scope if running the logging firehose tests
+    example: admin
+  autoscaler.cf.password:
+    description: Password of the admin user above.
+  autoscaler.acceptance.apps_domain:
+    description: >
+      A shared domain that tests can use to create subdomains that will route to
+      applications also created in the tests.
+    example: bosh-lite.com
+  autoscaler.acceptance.skip_ssl_validation:
+    description: >
+      Set to true if using an invalid (e.g. self-signed) cert for traffic routed
+      to your CF instance; this is generally always true for BOSH-Lite
+      deployments of CF.
+    default: false
+  autoscaler.acceptance.use_existing_user:
+    description: >
+      The admin user configured above will normally be used to create a
+      temporary user (with lesser permissions) to perform actions (such as push
+      applications) during tests, and then delete said user after the tests have
+      run; set this to true if you want to use an existing user, configured via
+      the following properties.
+    default: false
+  autoscaler.acceptance.keep_user_at_suite_end:
+    description: >
+      If using an existing user (see above), set this to true unless you are
+      okay having your existing user being deleted at the end. You can also set
+      this to true when not using an existing user if you want to leave the
+      temporary user around for debugging purposes after the test teardown.
+    default: false
+  autoscaler.acceptance.existing_user:
+    description: Name of the existing user to use.
+    example: cf-user
+  autoscaler.acceptance.existing_user_password:
+    description: Password for the existing user to use.
+  autoscaler.acceptance.default_timeout:
+    description: >
+      Default time (in seconds) to wait for polling assertions that wait for
+      asynchronous results.
+  autoscaler.acceptance.cf_push_timeout:
+    description: >
+      Default time (in seconds) to wait for cf push commands to succeed
+  autoscaler.acceptance.long_curl_timeout:
+    description: >
+      Default time (in seconds) to wait for assertions that curl slow endpoints
+      of test applications.
+  autoscaler.acceptance.test_password:
+    description: >
+      Used to set the password for the test user. This may be needed if your CF
+      installation has password policies.
+  autoscaler.acceptance.timeout_scale:
+    description: >
+      Used primarily to scale default timeouts for test setup and teardown
+      actions (e.g. creating an org) as opposed to main test actions (e.g.
+      pushing an app).
+  autoscaler.acceptance.use_http:
+    description: >
+      Set to true if you would like CF Acceptance Tests to use HTTP when making
+      api and application requests. (default is HTTPS)
+    default: false
+  autoscaler.acceptance.node_memory_limit:
+    description: >
+      the memory limit of node.js test application, should be greater than 128
+      (MB)
+  autoscaler.acceptance.java_buildpack_name:
+    description: The name of the Java buildpack
+    default: java_buildpack
+  autoscaler.acceptance.nodejs_buildpack_name:
+    description: The name of the Node.JS buildpack
+    default: nodejs_buildpack
+  autoscaler.service_broker.username:
+    description: username to authenticate with service broker
+  autoscaler.service_broker.password:
+    description: password to authenticate with service broker
+  autoscaler.service_broker.api_server.host:
+    description: Host where APIserver is running
+  autoscaler.service_broker.api_server.port:
+    description: Port where APIserver will listen

--- a/jobs/acceptance/templates/config.json.erb
+++ b/jobs/acceptance/templates/config.json.erb
@@ -1,0 +1,40 @@
+{
+    "service_name":                 "<%= p('autoscaler.acceptance.service_name') %>",
+    "service_plan":                 "<%= p('autoscaler.acceptance.service_plan') %>",
+    "aggregate_interval":           <%= p('autoscaler.eventgenerator.aggregator.aggregator_execute_interval').delete('s') %>,
+    "autoscaler_api":               "<%= p('autoscaler.acceptance.autoscaler_api') %>",
+    "api":                          "<%= p('autoscaler.acceptance.api') %>",
+    "admin_user":                   "<%= p('autoscaler.cf.username') %>",
+    "admin_password":               "<%= p('autoscaler.cf.password') %>",
+    "apps_domain":                  "<%= p('autoscaler.acceptance.apps_domain') %>",
+    "skip_ssl_validation":          <%= p('autoscaler.acceptance.skip_ssl_validation') %>,
+    "use_existing_user":            <%= p('autoscaler.acceptance.use_existing_user') %>,
+    "keep_user_at_suite_end":       <%= p('autoscaler.acceptance.keep_user_at_suite_end') %>,
+    <% if_p('autoscaler.acceptance.existing_user') do |v| %>
+        "existing_user":            "<%= v %>",
+    <% end %>
+    <% if_p('autoscaler.acceptance.existing_user_password') do |v| %>
+        "existing_user_password":   "<%= v %>",
+    <% end %>
+    <% if_p('autoscaler.acceptance.default_timeout') do |v|%>
+        "default_timeout":          <%= v %>,
+    <% end %>
+    <% if_p('autoscaler.acceptance.cf_push_timeout') do |v| %>
+        "cf_push_timeout":          <%= v %>,
+    <% end %>
+    <% if_p('autoscaler.acceptance.long_curl_timeout') do |v| %>
+        "long_curl_timeout":        <%= v %>,
+    <% end %>
+    <% if_p('autoscaler.acceptance.test_password') do |v| %>
+        "test_password":            "<%= v %>",
+    <% end %>
+    <% if_p('autoscaler.acceptance.timeout_scale') do |v| %>
+        "timeout_scale":            <%= v %>,
+    <% end %>
+    "use_http": <%= p('autoscaler.acceptance.use_http') %>,
+    <% if_p('autoscaler.acceptance.node_memory_limit') do |v| %>
+        "node_memory_limit":        <%= v %>,
+    <% end %>
+    "java_buildpack_name":          "<%= p('autoscaler.acceptance.java_buildpack_name') %>",
+    "nodejs_buildpack_name":        "<%= p('autoscaler.acceptance.nodejs_buildpack_name') %>"
+}

--- a/jobs/acceptance/templates/run.erb
+++ b/jobs/acceptance/templates/run.erb
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o xtrace
+
+export GOROOT="$(echo /var/vcap/packages/golang*)"
+export GOPATH="/var/vcap/packages/acceptance"
+export PATH="${PATH}:${GOROOT}/bin:${GOPATH}/bin"
+if test -d "/var/vcap/packages/cli" ; then
+    export PATH="${PATH}:/var/vcap/packages/cli/bin"
+fi
+export CONFIG="/var/vcap/jobs/acceptance/bin/config.json"
+cd "${GOPATH}/src/acceptance"
+
+cat "${CONFIG}"
+
+expected_broker='<%= p('autoscaler.acceptance.service_name') %>'
+actual_broker="$(cf curl /v2/service_brokers | jq -r ".resources[] | select(.entity.name == \"${expected_broker}\") | .entity.name")"
+if test "${expected_broker}" != "${actual_broker}" ; then
+    action="create"
+else
+    action="update"
+fi
+
+cf "${action}-service-broker" \
+    "${expected_broker}" \
+    '<%= p('autoscaler.service_broker.username') %>' \
+    '<%= p('autoscaler.service_broker.password') %>' \
+    'http://<%= p('autoscaler.service_broker.api_server.host') %>:<%= p('autoscaler.service_broker.api_server.port') %>'
+
+./bin/test_default

--- a/packages/acceptance/packaging
+++ b/packages/acceptance/packaging
@@ -1,0 +1,11 @@
+# abort script on any command that exits with a non zero value
+set -e
+
+mkdir -p ${BOSH_INSTALL_TARGET}/src
+ls -l
+cp -a \
+    acceptance \
+    github.com \
+    gopkg.in \
+    \
+    ${BOSH_INSTALL_TARGET}/src/

--- a/packages/acceptance/spec
+++ b/packages/acceptance/spec
@@ -1,0 +1,11 @@
+---
+name: acceptance
+
+dependencies:
+- golang1.7
+# cli
+
+files:
+- acceptance/**/*
+- github.com/**/*
+- gopkg.in/**/*

--- a/src/acceptance/README.md
+++ b/src/acceptance/README.md
@@ -58,7 +58,7 @@ The full set of config parameters is explained below:
 * `api` (required): Cloud Controller API endpoint.
 * `admin_user` (required): Name of a user in your CF instance with admin credentials.  This admin user must have the `doppler.firehose` scope if running the `logging` firehose tests.
 * `admin_password` (required): Password of the admin user above.
-* `apps_domain` (required): A shared domain that tests can use to create subdomains that will route to applications also craeted in the tests.
+* `apps_domain` (required): A shared domain that tests can use to create subdomains that will route to applications also created in the tests.
 
 * `skip_ssl_validation` (optional): Set to true if using an invalid (e.g. self-signed) cert for traffic routed to your CF instance; this is generally always true for BOSH-Lite deployments of CF.
 * `use_existing_user` (optional): The admin user configured above will normally be used to create a temporary user (with lesser permissions) to perform actions (such as push applications) during tests, and then delete said user after the tests have run; set this to `true` if you want to use an existing user, configured via the following properties.


### PR DESCRIPTION
This adds the acceptance tests as a BOSH task, so that it is easier to launch it separately.

I'm using this to test SUSE/scf#1594 (but it turns out to be not useful, because this takes an hour, and that's way too long for what we need).  This does _not_ actually block that from merging now.

I'm cheating here by pulling the `cli` package from a different release, so it's not actually listed in here.

Please let me know if I'm wrong on the properties; I'm just guessing based on the names.  In particular I'm uncertain that `aggregate_interval` is correct.

Thanks!