### PR TITLE
bump app-autoscaler to pick up build-in experience feature

### DIFF
--- a/jobs/apiserver/spec
+++ b/jobs/apiserver/spec
@@ -96,6 +96,10 @@ properties:
   autoscaler.api_server.metrics_collector.client_key:
     description: "PEM-encoded client key"
 
+  autoscaler.api_server.service_offering_enabled:
+    description: "the offering approach of auto-scaler"
+    default: true
+    
   autoscaler.api_server.service_broker.host:
     description: "Host where serviceBroker is running"
     default: "servicebroker.service.cf.internal"

--- a/jobs/apiserver/templates/config.json.erb
+++ b/jobs/apiserver/templates/config.json.erb
@@ -15,8 +15,7 @@
   scaling_engine_port = p('autoscaler.api_server.scaling_engine.port')
   metrics_collector_host = p('autoscaler.api_server.metrics_collector.host')
   metrics_collector_port = p('autoscaler.api_server.metrics_collector.port')
-  service_broker_host = p('autoscaler.api_server.service_broker.host')
-  service_broker_port = p('autoscaler.api_server.service_broker.port')
+  service_offering_enabled = p('autoscaler.api_server.service_offering_enabled')
 
   params = {
     'port' => p('autoscaler.api_server.port'),
@@ -54,26 +53,39 @@
            'caCertFile' => "/var/vcap/jobs/apiserver/config/certs/metricscollector/ca.crt"
        },
     },
-    'serviceBroker' => {
-       'uri' => "https://" + service_broker_host + ":" + service_broker_port.to_s,
-       'tls' => {
-           'keyFile' => "/var/vcap/jobs/apiserver/config/certs/servicebroker/client.key",
-           'certFile' => "/var/vcap/jobs/apiserver/config/certs/servicebroker/client.crt",
-           'caCertFile' => "/var/vcap/jobs/apiserver/config/certs/servicebroker/ca.crt"
-       },
-    },
     'tls' => {
         'keyFile' => "/var/vcap/jobs/apiserver/config/certs/apiserver/server.key",
         'certFile' => "/var/vcap/jobs/apiserver/config/certs/apiserver/server.crt",
         'caCertFile' => "/var/vcap/jobs/apiserver/config/certs/apiserver/ca.crt"
     },
-    # 'publicTls' => {
-    #     'keyFile' => "/var/vcap/jobs/apiserver/config/certs/apiserver/public_server.key",
-    #     'certFile' => "/var/vcap/jobs/apiserver/config/certs/apiserver/public_server.crt",
-    #     'caCertFile' => "/var/vcap/jobs/apiserver/config/certs/apiserver/public_ca.crt"
-    # },
   }
 %>
+
+<% if service_offering_enabled %>
+    <% 
+        service_broker_host = p('autoscaler.api_server.service_broker.host')
+        service_broker_port = p('autoscaler.api_server.service_broker.port').to_s
+
+        params["serviceOffering"] = {
+        'enabled' => service_offering_enabled,
+        'serviceBroker' => {
+            'uri' => "https://" + service_broker_host + ":" + service_broker_port,
+            'tls' => {
+                'keyFile' => "/var/vcap/jobs/apiserver/config/certs/servicebroker/client.key",
+                'certFile' => "/var/vcap/jobs/apiserver/config/certs/servicebroker/client.crt",
+                'caCertFile' => "/var/vcap/jobs/apiserver/config/certs/servicebroker/ca.crt"
+            },
+        },
+    }
+    %>
+<% else %>
+    <% params["serviceOffering"] = {
+        'enabled' => service_offering_enabled,
+    }
+    %>
+<% end %> 
+
+
 
 <%=JSON.pretty_generate(params, :indentation => 2)%> 
 

--- a/jobs/apiserver/templates/config.json.erb
+++ b/jobs/apiserver/templates/config.json.erb
@@ -67,7 +67,7 @@
         service_broker_port = p('autoscaler.api_server.service_broker.port').to_s
 
         params["serviceOffering"] = {
-        'enabled' => service_offering_enabled,
+        'enabled' => true,
         'serviceBroker' => {
             'uri' => "https://" + service_broker_host + ":" + service_broker_port,
             'tls' => {
@@ -80,7 +80,7 @@
     %>
 <% else %>
     <% params["serviceOffering"] = {
-        'enabled' => service_offering_enabled,
+        'enabled' => false,
     }
     %>
 <% end %> 

--- a/src/acceptance/api/api_suite_test.go
+++ b/src/acceptance/api/api_suite_test.go
@@ -123,11 +123,11 @@ var _ = AfterSuite(func() {
 		unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
 		Expect(unbindService).To(Exit(0), "failed unbinding service from app")
 
-		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(cfg.DefaultTimeoutDuration())).To(Exit(0))
 		deleteService := cf.Cf("delete-service", instanceName, "-f").Wait(cfg.DefaultTimeoutDuration())
 		Expect(deleteService).To(Exit(0))
 	}
 
+	Expect(cf.Cf("delete", appName, "-f", "-r").Wait(cfg.DefaultTimeoutDuration())).To(Exit(0))
 	workflowhelpers.AsUser(setup.AdminUserContext(), cfg.DefaultTimeoutDuration(), func() {
 		DisableServiceAccess(cfg, setup.GetOrganizationName())
 	})

--- a/src/acceptance/api/api_test.go
+++ b/src/acceptance/api/api_test.go
@@ -53,6 +53,10 @@ type HistoryResults struct {
 	Histories    []*AppScalingHistory `json:"resources"`
 }
 
+var (
+	oauthToken string
+)
+
 var _ = Describe("AutoScaler Public API", func() {
 
 	var (

--- a/src/acceptance/app/dynamic_policy_test.go
+++ b/src/acceptance/app/dynamic_policy_test.go
@@ -3,6 +3,9 @@ package app
 import (
 	"acceptance/config"
 	. "acceptance/helpers"
+	"bytes"
+	"fmt"
+	"net/http"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
@@ -23,15 +26,19 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		instanceName         string
 		initialInstanceCount int
 		policy               string
+		policyURL            string
+		oauthToken           string
 		doneChan             chan bool
 		doneAcceptChan       chan bool
 		ticker               *time.Ticker
 	)
 
 	BeforeEach(func() {
-		instanceName = generator.PrefixedRandomName("autoscaler", "service")
-		createService := cf.Cf("create-service", cfg.ServiceName, cfg.ServicePlan, instanceName).Wait(cfg.DefaultTimeoutDuration())
-		Expect(createService).To(Exit(0), "failed creating service")
+		if cfg.IsServiceOfferingEnabled() {
+			instanceName = generator.PrefixedRandomName("autoscaler", "service")
+			createService := cf.Cf("create-service", cfg.ServiceName, cfg.ServicePlan, instanceName).Wait(cfg.DefaultTimeoutDuration())
+			Expect(createService).To(Exit(0), "failed creating service")
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -43,28 +50,38 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		guid := cf.Cf("app", appName, "--guid").Wait(cfg.DefaultTimeoutDuration())
 		Expect(guid).To(Exit(0))
 		appGUID = strings.TrimSpace(string(guid.Out.Contents()))
-
 		Expect(cf.Cf("start", appName).Wait(cfg.CfPushTimeoutDuration())).To(Exit(0))
 		WaitForNInstancesRunning(appGUID, initialInstanceCount, cfg.DefaultTimeoutDuration())
+
+		if cfg.IsServiceOfferingEnabled() {
+			bindService := cf.Cf("bind-service", appName, instanceName, "-c", policy).Wait(cfg.DefaultTimeoutDuration())
+			Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
+		} else {
+			oauthToken = OauthToken(cfg)
+			policyURL = fmt.Sprintf("%s%s", cfg.ASApiEndpoint, strings.Replace(PolicyPath, "{appId}", appGUID, -1))
+			req, err := http.NewRequest("PUT", policyURL, bytes.NewBuffer([]byte(policy)))
+			req.Header.Add("Authorization", oauthToken)
+			req.Header.Add("Content-Type", "application/json")
+
+			resp, err := DoAPIRequest(req)
+			Expect(err).ShouldNot(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode == 200 || resp.StatusCode == 201).Should(BeTrue())
+		}
 	})
 
 	AfterEach(func() {
+		if cfg.IsServiceOfferingEnabled() {
+			unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
+			Expect(unbindService).To(Exit(0), "failed unbinding service from app")
+			deleteService := cf.Cf("delete-service", instanceName, "-f").Wait(cfg.DefaultTimeoutDuration())
+			Expect(deleteService).To(Exit(0))
+		}
+
 		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(cfg.DefaultTimeoutDuration())).To(Exit(0))
-		deleteService := cf.Cf("delete-service", instanceName, "-f").Wait(cfg.DefaultTimeoutDuration())
-		Expect(deleteService).To(Exit(0))
 	})
 
 	Context("when scaling by memoryused", func() {
-
-		JustBeforeEach(func() {
-			bindService := cf.Cf("bind-service", appName, instanceName, "-c", policy).Wait(cfg.DefaultTimeoutDuration())
-			Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
-		})
-
-		AfterEach(func() {
-			unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
-			Expect(unbindService).To(Exit(0), "failed unbinding service from app")
-		})
 
 		Context("when memory used is greater than scaling out threshold", func() {
 			BeforeEach(func() {
@@ -105,16 +122,6 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 	})
 
 	Context("when scaling by memoryutil", func() {
-
-		JustBeforeEach(func() {
-			bindService := cf.Cf("bind-service", appName, instanceName, "-c", policy).Wait(cfg.DefaultTimeoutDuration())
-			Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
-		})
-
-		AfterEach(func() {
-			unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
-			Expect(unbindService).To(Exit(0), "failed unbinding service from app")
-		})
 
 		Context("when memoryutil is greater than scaling out threshold", func() {
 			BeforeEach(func() {
@@ -157,8 +164,6 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 	Context("when scaling by responsetime", func() {
 
 		JustBeforeEach(func() {
-			bindService := cf.Cf("bind-service", appName, instanceName, "-c", policy).Wait(cfg.DefaultTimeoutDuration())
-			Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
 			doneChan = make(chan bool)
 			doneAcceptChan = make(chan bool)
 		})
@@ -166,8 +171,6 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		AfterEach(func() {
 			close(doneChan)
 			Eventually(doneAcceptChan, 10*time.Second).Should(Receive())
-			unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
-			Expect(unbindService).To(Exit(0), "failed unbinding service from app")
 		})
 
 		Context("when responsetime is greater than scaling out threshold", func() {
@@ -239,8 +242,6 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 	Context("when scaling by throughput", func() {
 
 		JustBeforeEach(func() {
-			bindService := cf.Cf("bind-service", appName, instanceName, "-c", policy).Wait(cfg.DefaultTimeoutDuration())
-			Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
 			doneChan = make(chan bool)
 			doneAcceptChan = make(chan bool)
 		})
@@ -248,8 +249,6 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		AfterEach(func() {
 			close(doneChan)
 			Eventually(doneAcceptChan, 10*time.Second).Should(Receive())
-			unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
-			Expect(unbindService).To(Exit(0), "failed unbinding service from app")
 		})
 
 		Context("when throughput is greater than scaling out threshold", func() {

--- a/src/acceptance/app/dynamic_policy_test.go
+++ b/src/acceptance/app/dynamic_policy_test.go
@@ -3,9 +3,6 @@ package app
 import (
 	"acceptance/config"
 	. "acceptance/helpers"
-	"bytes"
-	"fmt"
-	"net/http"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
@@ -26,8 +23,6 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 		instanceName         string
 		initialInstanceCount int
 		policy               string
-		policyURL            string
-		oauthToken           string
 		doneChan             chan bool
 		doneAcceptChan       chan bool
 		ticker               *time.Ticker
@@ -57,16 +52,7 @@ var _ = Describe("AutoScaler dynamic policy", func() {
 			bindService := cf.Cf("bind-service", appName, instanceName, "-c", policy).Wait(cfg.DefaultTimeoutDuration())
 			Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
 		} else {
-			oauthToken = OauthToken(cfg)
-			policyURL = fmt.Sprintf("%s%s", cfg.ASApiEndpoint, strings.Replace(PolicyPath, "{appId}", appGUID, -1))
-			req, err := http.NewRequest("PUT", policyURL, bytes.NewBuffer([]byte(policy)))
-			req.Header.Add("Authorization", oauthToken)
-			req.Header.Add("Content-Type", "application/json")
-
-			resp, err := DoAPIRequest(req)
-			Expect(err).ShouldNot(HaveOccurred())
-			defer resp.Body.Close()
-			Expect(resp.StatusCode == 200 || resp.StatusCode == 201).Should(BeTrue())
+			CreatePolicyWithAPI(appGUID, policy)
 		}
 	})
 

--- a/src/acceptance/app/recurring_schedule_policy_test.go
+++ b/src/acceptance/app/recurring_schedule_policy_test.go
@@ -19,11 +19,11 @@ var _ = Describe("AutoScaler recurring schedule policy", func() {
 	var (
 		appName              string
 		appGUID              string
-		instanceName         string
 		initialInstanceCount int
 		daysOfMonthOrWeek    Days
 		startTime            time.Time
 		endTime              time.Time
+		policy               string
 	)
 
 	BeforeEach(func() {
@@ -45,12 +45,8 @@ var _ = Describe("AutoScaler recurring schedule policy", func() {
 	})
 
 	AfterEach(func() {
+		DeletePolicy(appName, appGUID)
 		Expect(cf.Cf("delete", appName, "-f", "-r").Wait(cfg.DefaultTimeoutDuration())).To(Exit(0))
-
-		if cfg.IsServiceOfferingEnabled() {
-			deleteService := cf.Cf("delete-service", instanceName, "-f").Wait(cfg.DefaultTimeoutDuration())
-			Expect(deleteService).To(Exit(0))
-		}
 	})
 
 	Context("when scaling by recurring schedule", func() {
@@ -63,21 +59,9 @@ var _ = Describe("AutoScaler recurring schedule policy", func() {
 			location, err := time.LoadLocation("GMT")
 			Expect(err).NotTo(HaveOccurred())
 			startTime, endTime = getStartAndEndTime(location, 70*time.Second, time.Duration(interval+120)*time.Second)
-			policyStr := GenerateDynamicAndRecurringSchedulePolicy(cfg, 1, 4, 80, "GMT", startTime, endTime, daysOfMonthOrWeek, 2, 5, 3)
+			policy = GenerateDynamicAndRecurringSchedulePolicy(cfg, 1, 4, 80, "GMT", startTime, endTime, daysOfMonthOrWeek, 2, 5, 3)
 
-			if cfg.IsServiceOfferingEnabled() {
-				bindService := cf.Cf("bind-service", appName, instanceName, "-c", policyStr).Wait(cfg.DefaultTimeoutDuration())
-				Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
-			} else {
-				CreatePolicyWithAPI(appGUID, policyStr)
-			}
-		})
-
-		AfterEach(func() {
-			if cfg.IsServiceOfferingEnabled() {
-				unbindService := cf.Cf("unbind-service", appName, instanceName).Wait(cfg.DefaultTimeoutDuration())
-				Expect(unbindService).To(Exit(0), "failed unbinding service from app")
-			}
+			CreatePolicy(appName, appGUID, policy)
 		})
 
 		Context("with days of month", func() {
@@ -129,7 +113,7 @@ var _ = Describe("AutoScaler recurring schedule policy", func() {
 				}, jobRunTime, 15*time.Second).Should(Equal(2))
 
 				By("setting to default instance_min_count")
-				WaitForNInstancesRunning(appGUID, 1, time.Duration(interval+60)*time.Second)
+				WaitForNInstancesRunning(appGUID, 1, time.Duration(interval+120)*time.Second)
 			})
 		})
 	})

--- a/src/acceptance/app/recurring_schedule_policy_test.go
+++ b/src/acceptance/app/recurring_schedule_policy_test.go
@@ -3,9 +3,6 @@ package app
 import (
 	"acceptance/config"
 	. "acceptance/helpers"
-	"bytes"
-	"fmt"
-	"net/http"
 
 	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
 	"github.com/cloudfoundry-incubator/cf-test-helpers/generator"
@@ -27,8 +24,6 @@ var _ = Describe("AutoScaler recurring schedule policy", func() {
 		daysOfMonthOrWeek    Days
 		startTime            time.Time
 		endTime              time.Time
-		policyURL            string
-		oauthToken           string
 	)
 
 	BeforeEach(func() {
@@ -74,16 +69,7 @@ var _ = Describe("AutoScaler recurring schedule policy", func() {
 				bindService := cf.Cf("bind-service", appName, instanceName, "-c", policyStr).Wait(cfg.DefaultTimeoutDuration())
 				Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
 			} else {
-				oauthToken = OauthToken(cfg)
-				policyURL = fmt.Sprintf("%s%s", cfg.ASApiEndpoint, strings.Replace(PolicyPath, "{appId}", appGUID, -1))
-				req, err := http.NewRequest("PUT", policyURL, bytes.NewBuffer([]byte(policyStr)))
-				req.Header.Add("Authorization", oauthToken)
-				req.Header.Add("Content-Type", "application/json")
-
-				resp, err := DoAPIRequest(req)
-				Expect(err).ShouldNot(HaveOccurred())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode == 200 || resp.StatusCode == 201).Should(BeTrue())
+				CreatePolicyWithAPI(appGUID, policyStr)
 			}
 		})
 

--- a/src/acceptance/app/specificdate_schedule_policy_test.go
+++ b/src/acceptance/app/specificdate_schedule_policy_test.go
@@ -3,9 +3,6 @@ package app
 import (
 	"acceptance/config"
 	. "acceptance/helpers"
-	"bytes"
-	"fmt"
-	"net/http"
 
 	"strconv"
 	"strings"
@@ -27,8 +24,6 @@ var _ = Describe("AutoScaler specific date schedule policy", func() {
 		location             *time.Location
 		startDateTime        time.Time
 		endDateTime          time.Time
-		policyURL            string
-		oauthToken           string
 	)
 
 	BeforeEach(func() {
@@ -76,16 +71,7 @@ var _ = Describe("AutoScaler specific date schedule policy", func() {
 				bindService := cf.Cf("bind-service", appName, instanceName, "-c", policyStr).Wait(cfg.DefaultTimeoutDuration())
 				Expect(bindService).To(Exit(0), "failed binding service to app with a policy ")
 			} else {
-				oauthToken = OauthToken(cfg)
-				policyURL = fmt.Sprintf("%s%s", cfg.ASApiEndpoint, strings.Replace(PolicyPath, "{appId}", appGUID, -1))
-				req, err := http.NewRequest("PUT", policyURL, bytes.NewBuffer([]byte(policyStr)))
-				req.Header.Add("Authorization", oauthToken)
-				req.Header.Add("Content-Type", "application/json")
-
-				resp, err := DoAPIRequest(req)
-				Expect(err).ShouldNot(HaveOccurred())
-				defer resp.Body.Close()
-				Expect(resp.StatusCode == 200 || resp.StatusCode == 201).Should(BeTrue())
+				CreatePolicyWithAPI(appGUID, policyStr)
 			}
 		})
 

--- a/src/acceptance/broker/broker_suite_test.go
+++ b/src/acceptance/broker/broker_suite_test.go
@@ -31,8 +31,9 @@ func TestAcceptance(t *testing.T) {
 		helpers.EnableCFTrace(cfg, componentName)
 		rs = append(rs, helpers.NewJUnitReporter(cfg, componentName))
 	}
-
-	RunSpecsWithDefaultAndCustomReporters(t, componentName, rs)
+	if cfg.IsServiceOfferingEnabled() {
+		RunSpecsWithDefaultAndCustomReporters(t, componentName, rs)
+	}
 }
 
 var _ = BeforeSuite(func() {

--- a/src/acceptance/config/config.go
+++ b/src/acceptance/config/config.go
@@ -48,7 +48,8 @@ type Config struct {
 	CfJavaTimeout   int `json:"cf_java_timeout"`
 	NodeMemoryLimit int `json:"node_memory_limit"`
 
-	ASApiEndpoint string `json:"autoscaler_api"`
+	ASApiEndpoint          string `json:"autoscaler_api"`
+	ServiceOfferingEnabled bool   `json:"service_offering_enabled"`
 }
 
 var defaults = Config{
@@ -69,8 +70,9 @@ var defaults = Config{
 	ArtifactsDirectory:           filepath.Join("..", "results"),
 	NamePrefix:                   "ASATS",
 
-	CfJavaTimeout:   10,  // minutes
-	NodeMemoryLimit: 128, // MB
+	CfJavaTimeout:          10,  // minutes
+	NodeMemoryLimit:        128, // MB
+	ServiceOfferingEnabled: true,
 }
 
 func LoadConfig(t *testing.T) *Config {
@@ -135,6 +137,7 @@ func validate(t *testing.T, c *Config) {
 			}
 		}
 	}
+
 }
 
 func loadConfigFromPath(path string, config *Config) error {
@@ -251,4 +254,8 @@ func (c *Config) GetAdminPassword() string {
 
 func (c *Config) GetApiEndpoint() string {
 	return c.ApiEndpoint
+}
+
+func (c *Config) IsServiceOfferingEnabled() bool {
+	return c.ServiceOfferingEnabled
 }

--- a/templates/app-autoscaler-deployment-fewer.yml
+++ b/templates/app-autoscaler-deployment-fewer.yml
@@ -107,6 +107,7 @@ instance_groups:
     properties:
       autoscaler:
         api_server:
+          service_offering_enabled: true
           db_config: &db_config
             idle_timeout: 1000
             max_connections: 10
@@ -116,9 +117,6 @@ instance_groups:
           ca_cert: ((apiserver_ca.ca))
           server_cert: ((apiserver_server.certificate))
           server_key:  ((apiserver_server.private_key))
-          public_ca_cert: ((apiserver_public_ca.ca))
-          public_server_cert: ((apiserver_public_server.certificate))
-          public_server_key:  ((apiserver_public_server.private_key))
           scheduler:
             ca_cert: ((scheduler_ca.ca))
             client_cert: ((scheduler_client.certificate))

--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -103,6 +103,7 @@ instance_groups:
     properties:
       autoscaler:
         api_server:
+          service_offering_enabled: true
           db_config: &db_config
             idle_timeout: 1000
             max_connections: 10
@@ -112,9 +113,6 @@ instance_groups:
           ca_cert: ((apiserver_ca.ca))
           server_cert: ((apiserver_server.certificate))
           server_key:  ((apiserver_server.private_key))
-          public_ca_cert: ((apiserver_public_ca.ca))
-          public_server_cert: ((apiserver_public_server.certificate))
-          public_server_key:  ((apiserver_public_server.private_key))
           scheduler:
             ca_cert: ((scheduler_ca.ca))
             client_cert: ((scheduler_client.certificate))


### PR DESCRIPTION
In this PR,  we just add the deployment & acceptance changes for the build-in experience.  
All the default deployment options still aim to offer autoscaler as a service. 

Another document changes PR will be raised later to reflect how to deploy autoscaler as a build-in experience and how to config acceptance test with build-in experience. 