### PR TITLE
change the yaml anchors order to make sure anchors defined before they are referenced

### DIFF
--- a/templates/app-autoscaler-deployment-fewer.yml
+++ b/templates/app-autoscaler-deployment-fewer.yml
@@ -77,6 +77,122 @@ instance_groups:
           max_idle_connections: 10
           connection_max_lifetime: 60s
 
+# asactors Instance Group: scalingengine&scheduler&operator
+- name: asactors
+  azs:
+  - z1
+  instances: 1
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+  update:
+    max_in_flight: 1
+    serial: true
+  jobs:
+  - name: consul_agent
+    release: consul
+    consumes:
+      consul_common: {from: consul_common_link, deployment: cf}
+      consul_server: nil
+      consul_client: {from: consul_client_link, deployment: cf}
+    properties:
+      consul:
+        agent:
+          services:
+            scalingengine: 
+              check:
+                tcp: 127.0.0.1:6104
+                interval: 30s
+                timeout: 10s
+            autoscalerscheduler: 
+              check:
+                tcp: 127.0.0.1:6102
+                interval: 30s
+                timeout: 10s
+            operator: 
+              check: {}
+  - name: scalingengine
+    release: app-autoscaler
+    properties:
+      autoscaler:
+        scalingengine_db: *database
+        scheduler_db: *database
+        policy_db: *database
+        scalingengine_db_connection_config: *databaseConnectionConfig
+        scheduler_db_connection_config: *databaseConnectionConfig
+        policy_db_connection_config: *databaseConnectionConfig
+        cf: &cf_credentials
+          api: "https://api.((system_domain))"
+          grant_type: password
+          username: admin
+          password: "((cf_admin_password))"
+          client_id: ""
+          secret: ""
+          skip_ssl_validation: "((skip_ssl_validation))"
+        scalingengine:
+          logging:
+            level: debug
+          server:
+            port: &scalingEnginePort 6104
+          health:
+            port: &scalingEngineHealthPort 6204
+            emit_interval: 15s  
+          defaultCoolDownSecs: 300
+          lockSize: 32
+          ca_cert: ((scalingengine_ca.ca))
+          server_cert: ((scalingengine_server.certificate))
+          server_key: ((scalingengine_server.private_key))
+          require_consul: true
+  - name: scheduler
+    release: app-autoscaler
+    properties:
+      autoscaler:
+        scheduler:
+          port: &schedulerPort 6102
+          job_reschedule_interval_millisecond: 10000
+          job_reschedule_maxcount: 6
+          notification_reschedule_maxcount: 3
+          ca_cert: ((scheduler_ca.ca))
+          server_cert: ((scheduler_server.certificate))
+          server_key: ((scheduler_server.private_key))
+          scaling_engine:
+            ca_cert: ((scalingengine_ca.ca))
+            client_cert: ((scalingengine_client.certificate))
+            client_key: ((scalingengine_client.private_key))
+          require_consul: false
+        scheduler_db: *database
+        policy_db: *database
+  - name: operator
+    release: app-autoscaler
+    properties:
+      autoscaler:
+        appmetrics_db: *database
+        instancemetrics_db: *database
+        scalingengine_db: *database
+        appmetrics_db_connection_config: *databaseConnectionConfig
+        instancemetrics_db_connection_config: *databaseConnectionConfig
+        scalingengine_db_connection_config: *databaseConnectionConfig
+        lock_db: *database
+        operator:
+          scaling_engine:
+            port: *scalingEnginePort
+            ca_cert: ((scalingengine_ca.ca))
+            client_cert: ((scalingengine_client.certificate))
+            client_key: ((scalingengine_client.private_key))                
+          scheduler:
+            port: *schedulerPort
+            ca_cert: ((scheduler_ca.ca))
+            client_cert: ((scheduler_client.certificate))
+            client_key: ((scheduler_client.private_key))        
+          db_lock: 
+            ttl: 15s
+            retry_interval: 5s
+          enable_db_lock: false
+          logging:
+            level: debug 
+          require_consul: false
+
 # asapi Instance Group : apiserver&servicebroker
 - name: asapi
   azs:
@@ -239,14 +355,7 @@ instance_groups:
         policy_db: *database
         instancemetrics_db_connection_config: *databaseConnectionConfig
         policy_db_connection_config: *databaseConnectionConfig
-        cf: &cf_credentials
-          api: "https://api.((system_domain))"
-          grant_type: password
-          username: admin
-          password: "((cf_admin_password))"
-          client_id: ""
-          secret: ""
-          skip_ssl_validation: "((skip_ssl_validation))"
+        cf: *cf_credentials
         metricscollector:
           logging:
             level: debug
@@ -308,114 +417,7 @@ instance_groups:
           require_consul: true
   
 
-# asactors Instance Group: scalingengine&scheduler&operator
-- name: asactors
-  azs:
-  - z1
-  instances: 1
-  networks:
-  - name: default
-  stemcell: default
-  vm_type: minimal
-  update:
-    max_in_flight: 1
-    serial: true
-  jobs:
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul_common: {from: consul_common_link, deployment: cf}
-      consul_server: nil
-      consul_client: {from: consul_client_link, deployment: cf}
-    properties:
-      consul:
-        agent:
-          services:
-            scalingengine: 
-              check:
-                tcp: 127.0.0.1:6104
-                interval: 30s
-                timeout: 10s
-            autoscalerscheduler: 
-              check:
-                tcp: 127.0.0.1:6102
-                interval: 30s
-                timeout: 10s
-            operator: 
-              check: {}
-  - name: scalingengine
-    release: app-autoscaler
-    properties:
-      autoscaler:
-        scalingengine_db: *database
-        scheduler_db: *database
-        policy_db: *database
-        scalingengine_db_connection_config: *databaseConnectionConfig
-        scheduler_db_connection_config: *databaseConnectionConfig
-        policy_db_connection_config: *databaseConnectionConfig
-        cf: *cf_credentials
-        scalingengine:
-          logging:
-            level: debug
-          server:
-            port: &scalingEnginePort 6104
-          health:
-            port: &scalingEngineHealthPort 6204
-            emit_interval: 15s  
-          defaultCoolDownSecs: 300
-          lockSize: 32
-          ca_cert: ((scalingengine_ca.ca))
-          server_cert: ((scalingengine_server.certificate))
-          server_key: ((scalingengine_server.private_key))
-          require_consul: true
-  - name: scheduler
-    release: app-autoscaler
-    properties:
-      autoscaler:
-        scheduler:
-          port: &schedulerPort 6102
-          job_reschedule_interval_millisecond: 10000
-          job_reschedule_maxcount: 6
-          notification_reschedule_maxcount: 3
-          ca_cert: ((scheduler_ca.ca))
-          server_cert: ((scheduler_server.certificate))
-          server_key: ((scheduler_server.private_key))
-          scaling_engine:
-            ca_cert: ((scalingengine_ca.ca))
-            client_cert: ((scalingengine_client.certificate))
-            client_key: ((scalingengine_client.private_key))
-          require_consul: false
-        scheduler_db: *database
-        policy_db: *database
-  - name: operator
-    release: app-autoscaler
-    properties:
-      autoscaler:
-        appmetrics_db: *database
-        instancemetrics_db: *database
-        scalingengine_db: *database
-        appmetrics_db_connection_config: *databaseConnectionConfig
-        instancemetrics_db_connection_config: *databaseConnectionConfig
-        scalingengine_db_connection_config: *databaseConnectionConfig
-        lock_db: *database
-        operator:
-          scaling_engine:
-            port: *scalingEnginePort
-            ca_cert: ((scalingengine_ca.ca))
-            client_cert: ((scalingengine_client.certificate))
-            client_key: ((scalingengine_client.private_key))                
-          scheduler:
-            port: *schedulerPort
-            ca_cert: ((scheduler_ca.ca))
-            client_cert: ((scheduler_client.certificate))
-            client_key: ((scheduler_client.private_key))        
-          db_lock: 
-            ttl: 15s
-            retry_interval: 5s
-          enable_db_lock: false
-          logging:
-            level: debug 
-          require_consul: false
+
 
 variables:
 - name: database_password

--- a/templates/app-autoscaler-deployment.yml
+++ b/templates/app-autoscaler-deployment.yml
@@ -195,6 +195,63 @@ instance_groups:
             client_key: ((scalingengine_client.private_key))
         scheduler_db: *database
         policy_db: *database
+
+# Scaling-Engine Instance Group
+- name: scalingengine
+  azs:
+  - z1
+  instances: 1
+  networks:
+  - name: default
+  stemcell: default
+  vm_type: minimal
+  jobs:
+  - name: consul_agent
+    release: consul
+    consumes:
+      consul_common: {from: consul_common_link, deployment: cf}
+      consul_server: nil
+      consul_client: {from: consul_client_link, deployment: cf}
+    properties:
+      consul:
+        agent:
+          services:
+            scalingengine: 
+              check:
+                tcp: 127.0.0.1:6104
+                interval: 30s
+                timeout: 10s
+  - name: scalingengine
+    release: app-autoscaler
+    properties:
+      autoscaler:
+        scalingengine_db: *database
+        scheduler_db: *database
+        policy_db: *database
+        scalingengine_db_connection_config: *databaseConnectionConfig
+        scheduler_db_connection_config: *databaseConnectionConfig
+        policy_db_connection_config: *databaseConnectionConfig
+        cf: &cf_credentials
+          api: "https://api.((system_domain))"
+          grant_type: password
+          username: admin
+          password: "((cf_admin_password))"
+          client_id: ""
+          secret: ""
+          skip_ssl_validation: "((skip_ssl_validation))"
+        scalingengine:
+          logging:
+            level: debug
+          server:
+            port: &scalingEnginePort 6104
+          health:
+            port: &scalingEngineHealthPort 6204
+            emit_interval: 15s
+          defaultCoolDownSecs: 300
+          lockSize: 32
+          ca_cert: ((scalingengine_ca.ca))
+          server_cert: ((scalingengine_server.certificate))
+          server_key: ((scalingengine_server.private_key))
       
 # Service-Broker Instance Group
 - name: servicebroker
@@ -265,57 +322,6 @@ instance_groups:
           uris:
             - autoscalerservicebroker.((system_domain))
 
-# operator Instance Group
-- name: operator
-  azs:
-  - z1
-  instances: 1
-  networks:
-  - name: default
-  stemcell: default
-  vm_type: minimal
-  jobs:
-  - name: consul_agent
-    release: consul
-    consumes:
-      consul_common: {from: consul_common_link, deployment: cf}
-      consul_server: nil
-      consul_client: {from: consul_client_link, deployment: cf}
-    properties:
-      consul:
-        agent:
-          services:
-            operator: 
-              check: {}
-  - name: operator
-    release: app-autoscaler
-    properties:
-      autoscaler:
-        appmetrics_db: *database
-        instancemetrics_db: *database
-        scalingengine_db: *database
-        appmetrics_db_connection_config: *databaseConnectionConfig
-        instancemetrics_db_connection_config: *databaseConnectionConfig
-        scalingengine_db_connection_config: *databaseConnectionConfig
-        lock_db: *database
-        operator:
-          scaling_engine:
-            port: *scalingEnginePort
-            ca_cert: ((scalingengine_ca.ca))
-            client_cert: ((scalingengine_client.certificate))
-            client_key: ((scalingengine_client.private_key))                
-          scheduler:
-            port: *schedulerPort
-            ca_cert: ((scheduler_ca.ca))
-            client_cert: ((scheduler_client.certificate))
-            client_key: ((scheduler_client.private_key))
-          db_lock: 
-            ttl: 15s
-            retry_interval: 5s
-          enable_db_lock: false
-          logging:
-            level: debug 
-
 # Metric-collector Instance Group
 - name: metricscollector
   azs:
@@ -349,14 +355,7 @@ instance_groups:
         policy_db: *database
         instancemetrics_db_connection_config: *databaseConnectionConfig
         policy_db_connection_config: *databaseConnectionConfig
-        cf: &cf_credentials
-          api: "https://api.((system_domain))"
-          grant_type: password
-          username: admin
-          password: "((cf_admin_password))"
-          client_id: ""
-          secret: ""
-          skip_ssl_validation: "((skip_ssl_validation))"
+        cf: *cf_credentials
         metricscollector:
           logging:
             level: debug
@@ -441,8 +440,8 @@ instance_groups:
             client_cert: ((metricscollector_client.certificate))
             client_key: ((metricscollector_client.private_key))
 
-# Scaling-Engine Instance Group
-- name: scalingengine
+# operator Instance Group
+- name: operator
   azs:
   - z1
   instances: 1
@@ -461,35 +460,38 @@ instance_groups:
       consul:
         agent:
           services:
-            scalingengine: 
-              check:
-                tcp: 127.0.0.1:6104
-                interval: 30s
-                timeout: 10s
-  - name: scalingengine
+            operator: 
+              check: {}
+  - name: operator
     release: app-autoscaler
     properties:
       autoscaler:
+        appmetrics_db: *database
+        instancemetrics_db: *database
         scalingengine_db: *database
-        scheduler_db: *database
-        policy_db: *database
+        appmetrics_db_connection_config: *databaseConnectionConfig
+        instancemetrics_db_connection_config: *databaseConnectionConfig
         scalingengine_db_connection_config: *databaseConnectionConfig
-        scheduler_db_connection_config: *databaseConnectionConfig
-        policy_db_connection_config: *databaseConnectionConfig
-        cf: *cf_credentials
-        scalingengine:
+        lock_db: *database
+        operator:
+          scaling_engine:
+            port: *scalingEnginePort
+            ca_cert: ((scalingengine_ca.ca))
+            client_cert: ((scalingengine_client.certificate))
+            client_key: ((scalingengine_client.private_key))                
+          scheduler:
+            port: *schedulerPort
+            ca_cert: ((scheduler_ca.ca))
+            client_cert: ((scheduler_client.certificate))
+            client_key: ((scheduler_client.private_key))
+          db_lock: 
+            ttl: 15s
+            retry_interval: 5s
+          enable_db_lock: false
           logging:
-            level: debug
-          server:
-            port: &scalingEnginePort 6104
-          health:
-            port: &scalingEngineHealthPort 6204
-            emit_interval: 15s
-          defaultCoolDownSecs: 300
-          lockSize: 32
-          ca_cert: ((scalingengine_ca.ca))
-          server_cert: ((scalingengine_server.certificate))
-          server_key: ((scalingengine_server.private_key))
+            level: debug 
+
+
           
 variables:
 - name: database_password


### PR DESCRIPTION
There is a change in bosh cli release v4.0.1 to enforces that YAML anchors are already defined before they are referenced.

> https://github.com/cloudfoundry/bosh-cli/releases/tag/v4.0.1